### PR TITLE
CI: Add new dependencies to fix the build

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -10,9 +10,14 @@ jobs:
         dnf --assumeyes install gcc-c++ cmake git-core \
           'cmake(Qt6Core)' \
           'cmake(Qt6Gui)' \
+          'cmake(Qt6Quick)' \
           'cmake(Qt6UiTools)' \
           'cmake(Qt6Widgets)' \
           'cmake(KF6BluezQt)' \
+          'cmake(KF6CoreAddons)' \
+          'cmake(KF6I18n)' \
+          'cmake(KF6Kirigami)' \
+          'cmake(KF6QQC2DesktopStyle)' \
           extra-cmake-modules
     - uses: actions/checkout@v4
     - name: Build bluejay


### PR DESCRIPTION
Now that we have QtQuick and more KF6 dependencies, add them to the install step so we can build again.