### PR TITLE
README.md: fix url of logo.png

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,4 +1,4 @@
-# <img src="https://github.com/EbonJaeger/bluejay/blob/main/logo.png" width="64"> Bluejay
+# <img src="https://raw.githubusercontent.com/EbonJaeger/bluejay/main/logo.png" width="64" alt="logo"> Bluejay
 
 A Bluetooth manager and Bluez front-end. With it, you can pair devices, connect to and remove devices, turn Bluetooth on and off, and more. Bluejay is powered by the Qt6 graphical toolkit and KDE Frameworks.
 


### PR DESCRIPTION
    For links to work from everywhere (not only on github),
    links must point to raw.githubusercontent.com. This way
    the actual content gets served instead of the github page.