### PR TITLE
CMakeLists.txt - Don't include quiet packages in the feature summary

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -99,8 +99,7 @@ install(FILES io.github.ebonjaeger.bluejay.metainfo.xml
 install(FILES io.github.ebonjaeger.bluejay.svg
         DESTINATION ${KDE_INSTALL_FULL_ICONDIR}/hicolor/scalable/apps)
 
-feature_summary(WHAT ALL INCLUDE_QUIET_PACKAGES
-                         FATAL_ON_MISSING_REQUIRED_PACKAGES)
+feature_summary(WHAT ALL FATAL_ON_MISSING_REQUIRED_PACKAGES)
 
 file(GLOB_RECURSE ALL_CLANG_FORMAT_SOURCE_FILES src/*.cpp src/*.h)
 kde_clang_format(${ALL_CLANG_FORMAT_SOURCE_FILES})


### PR DESCRIPTION
Fixes:
```
Missing these optional packages:
 * Qt6QmlCompilerPlusPrivateTools (required version >= 6.10.0)
```